### PR TITLE
Delete unused namespace alias declaration css

### DIFF
--- a/layout/tables/BasicTableLayoutStrategy.cpp
+++ b/layout/tables/BasicTableLayoutStrategy.cpp
@@ -24,8 +24,6 @@
 using namespace mozilla;
 using namespace mozilla::layout;
 
-namespace css = mozilla::css;
-
 #undef DEBUG_TABLE_STRATEGY
 
 BasicTableLayoutStrategy::BasicTableLayoutStrategy(nsTableFrame* aTableFrame)


### PR DESCRIPTION
The procedure to fix this bug is a removal of unused declaration.